### PR TITLE
Quote paths to handle filenames with spaces for #136

### DIFF
--- a/app/services/riiif/image_magick_info_extractor.rb
+++ b/app/services/riiif/image_magick_info_extractor.rb
@@ -11,7 +11,7 @@ module Riiif
 
     def extract
       height, width, format, channels = Riiif::CommandRunner.execute(
-        "#{external_command} -format '%h %w %m %[channels]' #{@path}[0]"
+        "#{external_command} -format '%h %w %m %[channels]' '#{@path}[0]"
       ).split(' ')
 
       {

--- a/app/services/riiif/image_magick_info_extractor.rb
+++ b/app/services/riiif/image_magick_info_extractor.rb
@@ -11,7 +11,7 @@ module Riiif
 
     def extract
       height, width, format, channels = Riiif::CommandRunner.execute(
-        "#{external_command} -format '%h %w %m %[channels]' '#{@path}[0]"
+        "#{external_command} -format '%h %w %m %[channels]' '#{@path}[0]'"
       ).split(' ')
 
       {

--- a/app/services/riiif/imagemagick_command_factory.rb
+++ b/app/services/riiif/imagemagick_command_factory.rb
@@ -65,7 +65,7 @@ module Riiif
       end
 
       def input
-        " #{path}#{layer_spec}"
+        " '#{path}#{layer_spec}'"
       end
 
       # In cases where the input file has an alpha_channel but the transformation


### PR DESCRIPTION
This adds quotes around path names in shell commands, so that files with spaces in their names will not explode.