### PR TITLE
Update bixby to 5.0; drop coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Riiif
 [![Gem Version](https://badge.fury.io/rb/riiif.png)](http://badge.fury.io/rb/riiif)
-[![Coverage Status](https://coveralls.io/repos/github/curationexperts/riiif/badge.svg?branch=master)](https://coveralls.io/github/curationexperts/riiif?branch=master)
-
 
 A Ruby IIIF image server as a rails engine. 
 

--- a/app/controllers/riiif/images_controller.rb
+++ b/app/controllers/riiif/images_controller.rb
@@ -3,7 +3,7 @@ module Riiif
     before_action :link_header, only: [:show, :info]
 
     rescue_from IIIF::Image::InvalidAttributeError do
-      head 400
+      head :bad_request
     end
 
     def show

--- a/app/resolvers/riiif/akubra_system_file_resolver.rb
+++ b/app/resolvers/riiif/akubra_system_file_resolver.rb
@@ -5,6 +5,7 @@ module Riiif
     attr_accessor :pathroot, :imagetype, :akubraconfig
 
     def initialize(pr = '/yourfedora/data/datastreamStore/', ir = 'jp2', ac = [[0, 2], [2, 2], [4, 1]])
+      super()
       @pathroot = pr
       @imagetype = ir
       @akubraconfig = ac

--- a/riiif.gemspec
+++ b/riiif.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'engine_cart', '~> 2.0'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'bixby', '~> 3.0'
+  spec.add_development_dependency 'bixby', '~> 5.0'
   spec.add_development_dependency 'coveralls'
 end

--- a/riiif.gemspec
+++ b/riiif.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'bixby', '~> 5.0'
-  spec.add_development_dependency 'coveralls'
+  spec.add_development_dependency 'simplecov'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,4 @@
-require 'coveralls'
 require 'simplecov'
-
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-                                                                 SimpleCov::Formatter::HTMLFormatter,
-                                                                 Coveralls::SimpleCov::Formatter
-                                                               ])
 
 SimpleCov.start('rails')
 


### PR DESCRIPTION


The coveralls gem is no longer supported and causes TLS errors which break the build

