### PR TITLE
Improvements and bug fixes for Vips support

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Riiif::ImageMagickInfoExtractor.external_command  = "gm identify"
 
 You will of course need to install GraphicsMagick on your system.
 
-## Libvips (aka Vips)
+### Libvips (aka Vips)
 
 To use [libvips](https://www.libvips.org/) instead of ImageMagick
 

--- a/app/services/riiif/resize.rb
+++ b/app/services/riiif/resize.rb
@@ -10,27 +10,6 @@ module Riiif
 
     attr_reader :image_info, :size
 
-    # @return [Float] for Percent, Width, or Height
-    # @return [Array] for Absolute or BestFit: where 1st element is Integer & 2nd is a Hash
-    def to_vips
-      case size
-      when IIIF::Image::Size::Percent
-        size.percentage
-      when IIIF::Image::Size::Width
-        resize_ratio(:width, image_info, size)
-      when IIIF::Image::Size::Height
-        resize_ratio(:height, image_info, size)
-      when IIIF::Image::Size::Absolute
-        [size.width, { height: size.height, size: :force }]
-      when IIIF::Image::Size::BestFit
-        [size.width, { height: size.height }]
-      when IIIF::Image::Size::Max, IIIF::Image::Size::Full
-        nil
-      else
-        raise "unknown size #{size.class}"
-      end
-    end
-
     # @return [String] a resize directive for imagemagick to use
     def to_imagemagick
       case size
@@ -48,19 +27,6 @@ module Riiif
         nil
       else
         raise "unknown size #{size.class}"
-      end
-    end
-
-    # @param [Symbol] - which side of the image to calculate, either :width or :height
-    # @return [Float] - the scale or percentage to resize the image by; passed to Vips::Image#resize
-    def resize_ratio(side, image_info, size)
-      length = image_info.send(side)
-      target_length = size.send(side)
-
-      if target_length < length
-        target_length / length.to_f # Size down
-      else
-        length / target_length.to_f # Size up
       end
     end
 

--- a/app/services/riiif/vips_resize.rb
+++ b/app/services/riiif/vips_resize.rb
@@ -1,0 +1,47 @@
+module Riiif
+  # Represents a resize operation
+  class VipsResize
+    def initialize(size, image)
+      @size = size
+      @image = image
+    end
+
+    attr_reader :size, :image
+
+    # @return the parameters that vips will use to resize the image. This can be
+    #   1. A [Float] representing the scale factor, passed to Vips::Image#resize
+    #   2. An [Array], where the 1st elem is an Integer and the 2nd is a
+    #       Hash of options, passed to Vips::Image#thumbnail
+    #   3. [NilClass] when image should not be resized at all
+    def to_vips
+      case size
+      when IIIF::Image::Size::Percent
+        size.percentage
+      when IIIF::Image::Size::Width
+        resize_ratio(:width, image)
+      when IIIF::Image::Size::Height
+        resize_ratio(:height, image)
+      when IIIF::Image::Size::Absolute
+        [size.width, { height: size.height, size: :force }]
+      when IIIF::Image::Size::BestFit
+        [size.width, { height: size.height }]
+      when IIIF::Image::Size::Max, IIIF::Image::Size::Full
+        nil
+      else
+        raise "unknown size #{size.class}"
+      end
+    end
+
+    # @param [Symbol] - which side of the image to calculate, either :width or :height
+    # @return [Float] - the scale or percentage to resize the image by; passed to Vips::Image#resize
+    def resize_ratio(side, image)
+      length = image.send(side)
+      target_length = size.send(side)
+      if target_length < length
+        target_length / length.to_f # Size down
+      else
+        length / target_length.to_f # Size up
+      end
+    end
+  end
+end

--- a/app/transformers/riiif/vips_transformer.rb
+++ b/app/transformers/riiif/vips_transformer.rb
@@ -64,7 +64,7 @@ module Riiif
 
     def format_options
       format_string = [compression,
-                       ("optimize-coding" if transformation.format == 'jpg'),
+                       ("optimize-coding" if format == 'jpg'),
                        ("strip" if strip_metadata),
                        ("no-subsample" unless subsample)].select(&:present?).join(',')
 

--- a/app/transformers/riiif/vips_transformer.rb
+++ b/app/transformers/riiif/vips_transformer.rb
@@ -14,7 +14,7 @@ module Riiif
     # @param [IIIF::Image::Transformation] transformation
     def initialize(path, image_info, transformation, compression: 85, subsample: true, strip_metadata: true)
       super(path, image_info, transformation)
-      @image = ::Vips::Image.new_from_file(path)
+      @image = ::Vips::Image.new_from_file(path.to_s)
       @compression = compression
       @subsample = subsample
       @strip_metadata = strip_metadata

--- a/app/transformers/riiif/vips_transformer.rb
+++ b/app/transformers/riiif/vips_transformer.rb
@@ -40,6 +40,8 @@ module Riiif
         next image if options.blank?
 
         case method
+        when :resize
+          image.send(method, VipsResize.new(transformation.size, image).to_vips)
         when :thumbnail_image
           # .thumbnail_image needs a positional argument (width) and keyword args (options)
           # https://www.rubydoc.info/gems/ruby-vips/Vips/Image#thumbnail_image-instance_method
@@ -47,7 +49,7 @@ module Riiif
         when :crop
           # .crop needs positional arguments
           image.send(method, *options)
-        else
+        else # :rotate or :colourspace
           image.send(method, options)
         end
       end
@@ -74,9 +76,9 @@ module Riiif
     def resize
       case transformation.size
       when IIIF::Image::Size::Percent, IIIF::Image::Size::Width, IIIF::Image::Size::Height
-        [:resize, Resize.new(transformation.size, image_info).to_vips]
+        [:resize, transformation.size]
       else # IIIF::Image::Size::Absolute, IIIF::Image::Size::BestFit
-        [:thumbnail_image, Resize.new(transformation.size, image_info).to_vips]
+        [:thumbnail_image, VipsResize.new(transformation.size, image).to_vips]
       end
     end
 

--- a/docs/vips_comparison.md
+++ b/docs/vips_comparison.md
@@ -10,9 +10,9 @@ For a 4264 x 3282 jpeg image (26.8 MB)
 
 | Software Used  | Median processing time (ms) | Mean processing time (ms) |
 | ---------------|-----------------------------|---------------------------|
-| Imagemagick    |                         753 | 753                       |
-| Graphicsmagick |                         662 | 660                       |
-| Vips           |                          64 | 74                        |
+| Imagemagick    | 753                         | 753                       |
+| Graphicsmagick | 662                         | 660                       |
+| Vips           | 79                          | 78                        |
 
 ## Testing with a TIFF
 
@@ -22,7 +22,7 @@ For a 7800 x 5865 tif image (7.11 MB)
 | ---------------|-----------------------------|---------------------------|
 | Imagemagick    | 1091                        | 1089                      |
 | Graphicsmagick | 800                         | 796                       |
-| Vips           | 125                         | 129                       |
+| Vips           | 130                         | 139                       |
 
 ## More Resources & Discussion
 
@@ -115,33 +115,33 @@ Document Path:          /images/irises/full/!500,500/0/default.jpg
 Document Length:        77647 bytes
 
 Concurrency Level:      1
-Time taken for tests:   3.713 seconds
+Time taken for tests:   3.920 seconds
 Complete requests:      50
 Failed requests:        0
-Total transferred:      3926850 bytes
+Total transferred:      3926860 bytes
 HTML transferred:       3882350 bytes
-Requests per second:    13.46 [#/sec] (mean)
-Time per request:       74.268 [ms] (mean)
-Time per request:       74.268 [ms] (mean, across all concurrent requests)
-Transfer rate:          1032.70 [Kbytes/sec] received
+Requests per second:    12.75 [#/sec] (mean)
+Time per request:       78.409 [ms] (mean)
+Time per request:       78.409 [ms] (mean, across all concurrent requests)
+Transfer rate:          978.16 [Kbytes/sec] received
 
 Connection Times (ms)
               min  mean[+/-sd] median   max
 Connect:        0    0   0.0      0       0
-Processing:    64   74   7.5     75      93
-Waiting:       64   74   7.5     75      93
-Total:         64   74   7.5     75      93
+Processing:    67   78   5.5     79      90
+Waiting:       67   78   5.5     79      90
+Total:         67   78   5.5     79      90
 
 Percentage of the requests served within a certain time (ms)
-  50%     75
-  66%     77
-  75%     80
+  50%     79
+  66%     81
+  75%     81
   80%     82
   90%     86
   95%     88
-  98%     93
-  99%     93
- 100%     93 (longest request)
+  98%     90
+  99%     90
+ 100%     90 (longest request)
 ```
 
 ## Command and Detailed Results for TIFFs
@@ -227,31 +227,31 @@ Document Path:          /images/big/full/!500,500/0/default.jpg
 Document Length:        81878 bytes
 
 Concurrency Level:      1
-Time taken for tests:   6.459 seconds
+Time taken for tests:   6.661 seconds
 Complete requests:      50
 Failed requests:        0
-Total transferred:      4138454 bytes
+Total transferred:      4138502 bytes
 HTML transferred:       4093900 bytes
-Requests per second:    7.74 [#/sec] (mean)
-Time per request:       129.173 [ms] (mean)
-Time per request:       129.173 [ms] (mean, across all concurrent requests)
-Transfer rate:          625.74 [Kbytes/sec] received
+Requests per second:    7.51 [#/sec] (mean)
+Time per request:       133.222 [ms] (mean)
+Time per request:       133.222 [ms] (mean, across all concurrent requests)
+Transfer rate:          606.73 [Kbytes/sec] received
 
 Connection Times (ms)
               min  mean[+/-sd] median   max
 Connect:        0    0   0.0      0       0
-Processing:   106  129  14.7    125     177
-Waiting:      106  129  14.7    125     177
-Total:        106  129  14.7    125     177
+Processing:   115  133  12.0    130     160
+Waiting:      115  133  12.0    130     160
+Total:        115  133  12.0    130     160
 
 Percentage of the requests served within a certain time (ms)
-  50%    125
-  66%    134
-  75%    140
-  80%    141
-  90%    149
-  95%    157
-  98%    177
-  99%    177
- 100%    177 (longest request)
+  50%    130
+  66%    141
+  75%    143
+  80%    146
+  90%    150
+  95%    154
+  98%    160
+  99%    160
+ 100%    160 (longest request)
 ```

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,14 +18,4 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = 'random'
-
-  module Vips
-    class Image
-      # Left intentionally blank.
-      #
-      # This is here to prevent uninitialized constant errors when vips is not
-      # installed. Adding "require 'ruby-vips'" to specs will throw errors if
-      # vips is not installed.
-    end
-  end
 end

--- a/spec/transformers/riiif/vips_transformer_spec.rb
+++ b/spec/transformers/riiif/vips_transformer_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Riiif::VipsTransformer do
       let(:image) { double('Vips Image', has_alpha?: true) }
 
       it 'writes to png anyway to preserve transparency' do
-        expect(image).to receive(:write_to_buffer).with(".png[Q=85,optimize-coding,strip]")
+        expect(image).to receive(:write_to_buffer).with(".png[Q=85,strip]")
       end
     end
 

--- a/spec/transformers/riiif/vips_transformer_spec.rb
+++ b/spec/transformers/riiif/vips_transformer_spec.rb
@@ -32,6 +32,15 @@ RSpec.describe Riiif::VipsTransformer do
     allow(Vips::Image).to receive(:new_from_file).and_return(image)
   end
 
+  describe '#initialize' do
+    let(:path) { Pathname.new("path/to/image.tif") }
+
+    it 'normalizes pathnames to strings' do
+      expect(Vips::Image).to receive(:new_from_file).with("path/to/image.tif")
+      described_class.new(path, image_info, transformation)
+    end
+  end
+
   describe '#transform' do
     subject { described_class.new(path, image_info, transformation).transform }
     before { allow(image).to receive(:write_to_buffer) }

--- a/spec/transformers/riiif/vips_transformer_spec.rb
+++ b/spec/transformers/riiif/vips_transformer_spec.rb
@@ -1,5 +1,19 @@
 require 'spec_helper'
 
+  begin
+    require 'ruby-vips'
+  rescue LoadError
+    module Vips
+      class Image
+        # Intentionally blank.
+        #
+        # This prevents uninitialized constant errors if vips
+        # is not installed.
+      end
+    end
+  end
+
+
 RSpec.describe Riiif::VipsTransformer do
   let(:channels) { 'rgb' }
 

--- a/spec/transformers/riiif/vips_transformer_spec.rb
+++ b/spec/transformers/riiif/vips_transformer_spec.rb
@@ -133,17 +133,21 @@ RSpec.describe Riiif::VipsTransformer do
         context 'when specifing w, size' do
           let(:size) { IIIF::Image::Size::Width.new(300) }
 
+          before { allow(image).to receive(:width).and_return(600) }
+
           it 'resizes the image to 300px wide, maintaining aspect ratio' do
-            expect(image).to receive(:resize).with(0.6)
+            expect(image).to receive(:resize).with(0.5)
             subject
           end
         end
 
         context 'when specifing ,h size' do
-          let(:size) { IIIF::Image::Size::Height.new(752) }
+          let(:size) { IIIF::Image::Size::Height.new(200) }
+
+          before { allow(image).to receive(:height).and_return(500) }
 
           it 'resizes the image to 300px high, maintaining aspect ratio' do
-            expect(image).to receive(:resize).with(0.5)
+            expect(image).to receive(:resize).with(0.4)
             subject
           end
         end

--- a/spec/transformers/riiif/vips_transformer_spec.rb
+++ b/spec/transformers/riiif/vips_transformer_spec.rb
@@ -1,18 +1,17 @@
 require 'spec_helper'
 
-  begin
-    require 'ruby-vips'
-  rescue LoadError
-    module Vips
-      class Image
-        # Intentionally blank.
-        #
-        # This prevents uninitialized constant errors if vips
-        # is not installed.
-      end
+begin
+  require 'ruby-vips'
+rescue LoadError
+  module Vips
+    class Image
+      # Intentionally blank.
+      #
+      # This prevents uninitialized constant errors if vips
+      # is not installed.
     end
   end
-
+end
 
 RSpec.describe Riiif::VipsTransformer do
   let(:channels) { 'rgb' }


### PR DESCRIPTION
## Bug Fixes

* For pngs, the vips transformer should not write to file using the `optimize-coding` option. I've fixed this mistake in the vips transformer, and the mistake in `vips_transformer_spec` that allowed this bug to slip through.
* Vips previously resized images with the wrong scaling factor. This has been fixed.
* Updated benchmarking to reflect changes in resize command.

## Enhancements
* Downstream apps such as [Hyku may use pathname objects](https://github.com/samvera/hyku/blob/main/config/initializers/riiif.rb#L37) when setting not_found or unauthorized images, which causes an error when initializing the Vips::Image. Normalizing pathnames to strings in the transformer's initializer prevents this error.